### PR TITLE
Fix user dn when adding groups members via ldap

### DIFF
--- a/idm/load_test.py
+++ b/idm/load_test.py
@@ -311,7 +311,7 @@ def mod_group_users_ldap(users, ldap_conn, base_user_dn, group_dn, ldap_mod_op, 
   if chunk==-1:
     chunk=len(users)
 
-  user_dn_list = ["uid={},{}".format(user,base_user_dn) for user in users]
+  user_dn_list = [base_user_dn.format(user) for user in users]
 
   for user_dn_chunk in chunker(user_dn_list,chunk):
     # print(user_dn_chunk)


### PR DESCRIPTION
The base_user_dn in load_test.py already contains the 'uid={}' string.
As a consequence of this mistake, the "member" attribute of the group
was populated with the wrong string for user dns and the "memberof"
attribute of the users were not populated.

This commit fixes the mod_group_users_ldap method to use base_user_dn
as a template for formating rather than a suffix for appending to the
uid.